### PR TITLE
Specify SourceType for music

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -30,7 +30,7 @@ function love.load()
 	defaultCursor = love.graphics.newImage("img/mouse_cursor.png")
 	mouseImg = defaultCursor
 
-	music = love.audio.newSource("img/music.mp3")
+	music = love.audio.newSource("img/music.mp3", "stream")
 	music:play()
 	musicVolume = 0 --da ne slusamo stalno
 	love.audio.setVolume(musicVolume)


### PR DESCRIPTION
Versions of LÖVE older than 11.0 would default to `stream`, but newer versions require passing this argument explicitly. From [the docs](https://www.love2d.org/wiki/SourceType):

> A good rule of thumb is to use `stream` for music files and `static` for all short sound effects. Basically, you want to avoid loading large files into memory at once.

The updated code now is now compatible with LÖVE 11.5 (Mysterious Mysteries).